### PR TITLE
Future: Use more descriptive varname in public api

### DIFF
--- a/lib/Future.php
+++ b/lib/Future.php
@@ -5,8 +5,8 @@ namespace Amphp\Redis;
 class Future extends \Amp\Future {
 	private $callback;
 
-	public function __construct($callback = null) {
-		$this->callback = $callback;
+	public function __construct(callable $successCallback = null) {
+		$this->callback = $successCallback;
 	}
 
 	public function succeed($result = null) {


### PR DESCRIPTION
Also adds a typehint of `callable`
