### PR TITLE
Require min php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
 		"issues": "https://github.com/kelunik/amp-redis"
 	},
 	"require": {
+                "php": "~5.6",
 		"amphp/amp": "~0.15",
 		"rdlowrey/nbsock": "~0.5"
 	},


### PR DESCRIPTION
Atm its php 5.6 because `use function` is used (maybe other 5.6 only features)
