### PR TITLE
Check state before `send` and throw exception when not yet ready.

### DIFF
--- a/lib/Redis.php
+++ b/lib/Redis.php
@@ -268,6 +268,10 @@ class Redis {
 	}
 
 	private function send ($strings, callable $callback = null) {
+                if (!$this->isAlive()) {
+                        throw new Exception("Redis is not ready. You either forgot to connect() or already close()'ed the connection");
+                }
+
 		$payload = "";
 
 		foreach ($strings as $string) {


### PR DESCRIPTION
I decided to throw a Exception instead of returning `Failure` because the cause is likely a programming mistake and not something which should be handled at runtime.
