### PR TITLE
removed `use` typo of Doctrine UnexpectedValueException

### DIFF
--- a/lib/Redis.php
+++ b/lib/Redis.php
@@ -16,7 +16,6 @@
 namespace Amphp\Redis;
 
 use Amp\Reactor;
-use Doctrine\Instantiator\Exception\UnexpectedValueException;
 use Nbsock\Connector;
 use function Amp\cancel;
 use function Amp\getReactor;


### PR DESCRIPTION
seems to be auto-added by phpstorm by mistake
