### PR TITLE
use RedisException

### DIFF
--- a/lib/Redis.php
+++ b/lib/Redis.php
@@ -101,7 +101,7 @@ class Redis {
 			}
 
 			if (!is_resource($socket) || @feof($socket)) {
-				throw new \Exception("Connection could not be initialised!");
+				throw new RedisException("Connection could not be initialised!");
 			}
 
 			$this->socket = $socket;


### PR DESCRIPTION
use proper Exception-type when `"Connection could not be initialised!"`
