### PR TITLE
Improved Promise usage

### DIFF
--- a/lib/RespParser.php
+++ b/lib/RespParser.php
@@ -16,6 +16,11 @@ class RespParser {
 		$this->responseCallback = $responseCallback;
 	}
 
+	public function reset() {
+		$this->buffer = "";
+		$this->currentResponse = $this->arrayStack = $this->currentSize = $this->arraySizes = null;
+	}
+
 	public function append ($str) {
 		$this->buffer .= $str;
 


### PR DESCRIPTION
- `Redis::connect()` now always returns a promise.
- Only throw on user input errors.
- Cleanup parser and Redis state upon connection close/severing so the same instance can be reused upon reconnection.
- Change references to "future" to "promisor." Amp libs really should be using "promisor" and "promise" as these are the actual interfaces. `Future` is really just a one-size-fits-all implementation of both the `Promisor` and `Promise` interfaces. I'd prefer if everyone referenced these things by the appropriate terms so it's easier to understand what's happening in async code.