### PR TITLE
[WIP] Separate connection and client responsibility

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -49,7 +49,7 @@ class Client extends Redis
             }
         });
 
-        if (!empty($this->connection->getPassword())) {
+        if ($this->connection->hasPassword()) {
             $this->connection->addEventHandler("connect", function () {
                 // AUTH must be before any other command, so we unshift it last
                 \array_unshift($this->deferreds, new Deferred);

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -2,17 +2,12 @@
 
 namespace Amp\Redis;
 
-use Amp\Deferred;
 use Amp\Promise;
 use Amp\Uri\InvalidUriException;
-use Exception;
 use function Amp\call;
 
 class Client extends Redis
 {
-    /** @var Deferred[] */
-    private $deferreds;
-
     /** @var Connection */
     private $connection;
 
@@ -22,52 +17,7 @@ class Client extends Redis
      */
     public function __construct(string $uri)
     {
-        $this->deferreds = [];
-        $this->connection = new Connection($uri);
-
-        $this->connection->addEventHandler("response", function ($response) {
-            $deferred = \array_shift($this->deferreds);
-
-            if (empty($this->deferreds)) {
-                $this->connection->setIdle(true);
-            }
-
-            if ($response instanceof Exception) {
-                $deferred->fail($response);
-            } else {
-                $deferred->resolve($response);
-            }
-        });
-
-        $this->connection->addEventHandler(["close", "error"], function ($error = null) {
-            if ($error) {
-                // Fail any outstanding promises
-                while ($this->deferreds) {
-                    $deferred = \array_shift($this->deferreds);
-                    $deferred->fail($error);
-                }
-            }
-        });
-
-        if ($this->connection->hasPassword()) {
-            $this->connection->addEventHandler("connect", function () {
-                // AUTH must be before any other command, so we unshift it last
-                \array_unshift($this->deferreds, new Deferred);
-                $password = $this->connection->getPassword();
-
-                return "*2\r\n$4\r\rAUTH\r\n$" . \strlen($password) . "\r\n{$password}\r\n";
-            });
-        }
-
-        if ($this->connection->getDatabase() !== 0) {
-            $this->connection->addEventHandler("connect", function () {
-                // SELECT must be called for every new connection if another database than 0 is used
-                \array_unshift($this->deferreds, new Deferred);
-                $database = $this->connection->getDatabase();
-
-                return "*2\r\n$6\r\rSELECT\r\n$" . \strlen($database) . "\r\n{$database}\r\n";
-            });
-        }
+        $this->connection = new Connection(ConnectionConfig::parse($uri));
     }
 
     /**
@@ -83,15 +33,7 @@ class Client extends Redis
      */
     public function close(): Promise
     {
-        $promise = Promise\all(\array_map(function (Deferred $deferred) {
-            return $deferred->promise();
-        }, $this->deferreds));
-
-        $promise->onResolve(function () {
-            $this->connection->close();
-        });
-
-        return $promise;
+        return $this->connection->close();
     }
 
     /**
@@ -103,13 +45,7 @@ class Client extends Redis
     protected function send(array $args, callable $transform = null): Promise
     {
         return call(function () use ($args, $transform) {
-            $deferred = new Deferred;
-            $promise = $deferred->promise();
-
-            $this->deferreds[] = $deferred;
-
-            yield $this->connection->send($args);
-            $response = yield $promise;
+            $response = yield $this->connection->send($args);
 
             return $transform ? $transform($response) : $response;
         });

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -138,7 +138,7 @@ class Connection
             }
         }
 
-        call(function () use ($strings, $deferred) {
+        call(function () use ($strings) {
             $this->setIdle(false);
 
             $payload = "";

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -90,7 +90,6 @@ class Connection
      * @link http://www.iana.org/assignments/uri-schemes/prov/redis
      *
      * @param string $uri URI string.
-     * 
      * @throws InvalidUriException
      */
     private function applyUri(string $uri)

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -7,11 +7,10 @@ use Amp\Promise;
 use Amp\Socket\ClientConnectContext;
 use Amp\Socket\Socket;
 use Amp\Success;
-use Amp\Uri\InvalidUriException;
+use Exception;
 use function Amp\asyncCall;
 use function Amp\call;
 use function Amp\Socket\connect;
-use Exception;
 
 class Connection
 {
@@ -67,6 +66,9 @@ class Connection
 
             if (empty($this->deferreds)) {
                 $this->setIdle(true);
+            }
+            if (!$deferred instanceof Deferred) {
+                return;
             }
 
             if ($response instanceof Exception) {

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -12,7 +12,6 @@ use Amp\Uri\Uri;
 use function Amp\asyncCall;
 use function Amp\call;
 use function Amp\Socket\connect;
-use Exception;
 
 class Connection
 {

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -279,6 +279,11 @@ class Connection
         return $this->password;
     }
 
+    public function hasPassword(): bool
+    {
+        return (bool) \strlen($this->database);
+    }
+
     public function getDatabase(): int
     {
         return $this->database;

--- a/lib/ConnectionConfig.php
+++ b/lib/ConnectionConfig.php
@@ -123,5 +123,4 @@ class ConnectionConfig
     {
         return $this->database;
     }
-
 }

--- a/lib/ConnectionConfig.php
+++ b/lib/ConnectionConfig.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Redis;
+
+use Amp\Uri\InvalidUriException;
+use Amp\Uri\Uri;
+
+class ConnectionConfig
+{
+    const DEFAULT_HOST = "localhost";
+    const DEFAULT_PORT = "6379";
+
+    /** @var string */
+    private $uri;
+
+    /** @var string */
+    private $password = '';
+
+    /** @var int */
+    private $database = 0;
+
+    /** @var int */
+    private $timeout = 5000;
+
+    /**
+     * @param string $uri
+     * @return ConnectionConfig
+     * @throws InvalidUriException
+     */
+    public static function parse(string $uri): self
+    {
+        if (\strpos($uri, "tcp://") !== 0 &&
+            \strpos($uri, "unix://") !== 0 &&
+            \strpos($uri, "redis://") !== 0
+        ) {
+            throw new InvalidUriException("URI must start with tcp://, unix:// or redis://");
+        }
+
+        return new self($uri);
+    }
+
+    /**
+     * @param string $uri
+     * @throws InvalidUriException
+     */
+    public function __construct(string $uri)
+    {
+        $this->applyUri($uri);
+    }
+
+    /**
+     * When using the "redis" schemes the URI is parsed according
+     * to the rules defined by the provisional registration documents approved
+     * by IANA. If the URI has a password in its "user-information" part or a
+     * database number in the "path" part these values override the values of
+     * "password" and "database" if they are present in the "query" part.
+     *
+     * @link http://www.iana.org/assignments/uri-schemes/prov/redis
+     *
+     * @param string $uri URI string.
+     * @throws InvalidUriException
+     */
+    private function applyUri(string $uri)
+    {
+        $uri = new Uri($uri);
+
+        switch ($uri->getScheme()) {
+            case "tcp":
+                $this->uri = "tcp://" . $uri->getHost() . ":" . $uri->getPort();
+                $this->database = (int) ($uri->getQueryParameter("database") ?? 0);
+                $this->password = $uri->getQueryParameter("password") ?? "";
+                break;
+
+            case "unix":
+                $this->uri = "unix://" . $uri->getPath();
+                $this->database = (int) ($uri->getQueryParameter("database") ?? 0);
+                $this->password = $uri->getQueryParameter("password") ?? "";
+                break;
+
+            case "redis":
+                $this->uri = \sprintf(
+                    "tcp://%s:%d",
+                    $uri->getHost() ?? self::DEFAULT_HOST,
+                    $uri->getPort() ?? self::DEFAULT_PORT
+                );
+                if ($uri->getPath() !== "/") {
+                    $this->database = (int) \ltrim($uri->getPath(), "/");
+                } else {
+                    $this->database = (int) ($uri->getQueryParameter("db") ?? 0);
+                }
+                if (!empty($uri->getPass())) {
+                    $this->password = $uri->getPass();
+                } else {
+                    $this->password = $uri->getQueryParameter("password") ?? "";
+                }
+                break;
+        }
+
+        $this->timeout = $uri->getQueryParameter("timeout") ?? $this->timeout;
+    }
+
+    public function getUri(): string
+    {
+        return $this->uri;
+    }
+
+    public function getTimeout(): int
+    {
+        return $this->timeout;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function hasPassword(): bool
+    {
+        return (bool) \strlen($this->password);
+    }
+
+    public function getDatabase(): int
+    {
+        return $this->database;
+    }
+
+}

--- a/lib/SubscribeClient.php
+++ b/lib/SubscribeClient.php
@@ -5,6 +5,7 @@ namespace Amp\Redis;
 use Amp\Deferred;
 use Amp\Emitter;
 use Amp\Promise;
+use Amp\Uri\InvalidUriException;
 use Amp\Uri\Uri;
 use Exception;
 use function Amp\call;
@@ -28,12 +29,13 @@ class SubscribeClient
 
     /**
      * @param string $uri
+     * @throws InvalidUriException
      */
     public function __construct(string $uri)
     {
         $this->applyUri($uri);
 
-        $this->connection = new Connection($uri);
+        $this->connection = new Connection(ConnectionConfig::parse($uri));
         $this->connection->addEventHandler("response", function ($response) {
             if ($this->authDeferred) {
                 if ($response instanceof Exception) {

--- a/test/SelectTest.php
+++ b/test/SelectTest.php
@@ -26,10 +26,37 @@ class SelectTest extends RedisTest
     /**
      * @test
      */
+    public function connectWithRedisUrl()
+    {
+        Loop::run(function () {
+            $redis = new Client("redis://:secret@127.0.0.1:25325/1");
+            $this->assertEquals("PONG", (yield $redis->ping()));
+        });
+    }
+
+    /**
+     * @test
+     */
     public function select()
     {
         Loop::run(function () {
             $redis1 = new Client("tcp://127.0.0.1:25325?database=1&password=secret");
+            $payload = "bar";
+            yield $redis1->set("foobar", $payload);
+            $this->assertEquals($payload, (yield $redis1->get("foobar")));
+
+            $redis0 = new Client("tcp://127.0.0.1:25325?password=secret");
+            $this->assertNotEquals($payload, (yield $redis0->get("foobar")));
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function selectWithRedisUrl()
+    {
+        Loop::run(function () {
+            $redis1 = new Client("redis://:secret@127.0.0.1:25325/1");
             $payload = "bar";
             yield $redis1->set("foobar", $payload);
             $this->assertEquals($payload, (yield $redis1->get("foobar")));


### PR DESCRIPTION
The idea behind this is to separate responsibility of proper connecting with `AUTH` and `SELECT` inside `Connection` class. 
So the client is responsible for sending commands and transforming a result.
This introduces `ConnectionConfig` as well cause we got 3 different URI formats now.