### PR TITLE
Fix Redis::get() return type

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -477,7 +477,7 @@ final class Redis
     /**
      * @param string $key
      *
-     * @return Promise<string>
+     * @return Promise<string|null>
      *
      * @link https://redis.io/commands/get
      */


### PR DESCRIPTION
Some other methods might have similar issue but I'm not sure how to tell (had to go and test this one).