### PR TITLE
Fixed return type for RedistList::get()

### DIFF
--- a/src/Command/RedisList.php
+++ b/src/Command/RedisList.php
@@ -21,8 +21,10 @@ final class RedisList
 
     /**
      * @link https://redis.io/commands/lindex
+     *
+     * TODO: Change type declaration to int only in next major.
      */
-    public function get(string $index): string
+    public function get(string|int $index): ?string
     {
         return $this->client->execute('lindex', $this->key, $index);
     }

--- a/test/Command/RedisListTest.php
+++ b/test/Command/RedisListTest.php
@@ -51,6 +51,7 @@ class RedisListTest extends IntegrationTest
         $this->assertSame('y', $list->popHeadBlocking());
         $this->assertSame('b', $list->popTailBlocking());
 
+        $this->assertNull($this->redis->getList('nonexistent')->get(0));
         $this->assertNull($this->redis->getList('nonexistent')->popHeadBlocking(1));
         $this->assertNull($this->redis->getList('nonexistent')->popTailBlocking(1));
         $this->assertNull($this->redis->getList('nonexistent')->popTailPushHeadBlocking('nonexistent', 1));


### PR DESCRIPTION
This fixes a bug that caused the following exception to be thrown when the list key did not exist:
>TypeError : Amp\Redis\Command\RedisList::get(): Return value must be of type string, null returned

As a bonus, we expanded the allowed types for `RedistList::get` to include integer, which is probably the type it should have always been. We don't replace `string` at this time, though, for BC reasons.