### PR TITLE
fix `hget` returned TypeError

### DIFF
--- a/src/Command/RedisMap.php
+++ b/src/Command/RedisMap.php
@@ -96,7 +96,7 @@ final class RedisMap
     /**
      * @link https://redis.io/commands/hget
      */
-    public function getValue(string $field): string
+    public function getValue(string $field): ?string
     {
         return $this->client->execute('hget', $this->key, $field);
     }

--- a/test/Command/RedisMapTest.php
+++ b/test/Command/RedisMapTest.php
@@ -15,6 +15,8 @@ class RedisMapTest extends IntegrationTest
         $this->assertSame([], $map->getKeys());
         $this->assertSame([], $map->getAll());
 
+        $this->assertNull($map->getValue('foo'));
+
         $map->setValues([
             'foo' => 'bar',
             'rofl' => 'lol',


### PR DESCRIPTION
Fixing error in php 8.4:
```
TypeError: Amp\Redis\Command\RedisMap::getValue(): Return value must be of type string, null returned
```